### PR TITLE
fixes `python-seabreeze` SeaBreezeAPI calls

### DIFF
--- a/example/simple/client.py
+++ b/example/simple/client.py
@@ -1,7 +1,7 @@
 from seabreeze_server.client import SeaBreezeClient
 from seabreeze_server.errors import SeaBreezeServerError, CallMethodError
 # Testing
-HOST, PORT = 'localhost', 9999
+HOST, PORT = 'localhost', 2999
 client = SeaBreezeClient(HOST, PORT)
 print("repr:",client)
 print("dev_list:",client.list_devices())
@@ -11,11 +11,11 @@ print("Setting Integration Time : 10 ms")
 client.set_integration_time_micros(10*1000)
 print("intensities: ",client.get_intensities())
 client.deselect_spectrometer()
-try:
-    client.serial_number() # Raise SeaBreezeServerError
-except SeaBreezeServerError as e:
-    print("Caught the following error as SeaBreezeServerError:",e)
-try:
-    client.serial_number() # Raise SeaBreezeServerError
-except CallMethodError as e:
-    print("Caught the following error as CallMethodError:",e)
+# try:
+#     client.serial_number() # Raise SeaBreezeServerError
+# except SeaBreezeServerError as e:
+#     print("Caught the following error as SeaBreezeServerError:",e)
+# try:
+#     client.serial_number() # Raise SeaBreezeServerError
+# except CallMethodError as e:
+#     print("Caught the following error as CallMethodError:",e)

--- a/example/simple/server.py
+++ b/example/simple/server.py
@@ -1,6 +1,6 @@
 import seabreeze_server as sbs
 
-HOST, PORT = 'localhost', 9999
+HOST, PORT = 'localhost', 2999
 
 with sbs.server.SeaBreezeServer((HOST, PORT), emulate=True) as server:
     print("Hosting @",server.server_address)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ future==0.18.2
 numpy==1.18.2
 remote-object==0.2.4
 seabreeze==1.0.1
-seatease==0.3.2
+seatease==0.4.0

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="seabreeze-server",
-    version="0.2.0",
+    version="0.2.1",
     author="Jonathan D B Van Schenck",
     author_email="vanschej@oregonstate.edu",
     description="A TCP server to host the `python-seabreeze.cseabreeze` backend",


### PR DESCRIPTION
Two problems this fixes. 
1) The server didn't used to call `.open()` on the device, which worked for `seatease` (since that emulation library does check if the device is open), but fails for `seabreeze` (since that library DOES). This fixes that
2) Old `seatease` (version>0.4) had a weird way of importing the backend `SeaTeaseAPI`, which was inconsistent with `seabreeze`. That was fixed, and so the code here needed to be updated to use the new version of `seatease`.